### PR TITLE
Simplification of hotkey config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use {
     livesplit_core::{
         layout::{self, Layout, LayoutSettings},
         run::{parser::composite, saver::livesplit::save_timer},
-        HotkeyConfig, HotkeySystem, Run, Segment, Timer, TimingMethod,
+        HotkeyConfig, Run, Segment, Timer, TimingMethod,
     },
     serde::Deserialize,
     std::{
@@ -124,8 +124,8 @@ impl Config {
         self.general.splits = Some(path);
     }
 
-    pub fn configure_hotkeys(&self, hotkeys: &mut HotkeySystem) {
-        hotkeys.set_config(self.hotkeys.clone()).ok();
+    pub fn hotkey_config(&self) -> HotkeyConfig {
+        self.hotkeys
     }
 
     pub fn configure_timer(&self, timer: &mut Timer) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ fn main() {
 
     let mut markers = config.build_marker_client();
 
-    let mut hotkey_system = HotkeySystem::new(timer.clone()).unwrap();
-    config.configure_hotkeys(&mut hotkey_system);
+    let mut hotkey_system = HotkeySystem::with_config(timer.clone(), config.hotkey_config()).unwrap();
 
     let mut layout = config.parse_layout_or_default();
 


### PR DESCRIPTION
The config struct now has a method that returns the hotkey struct (which is copy, so no cloning is necessary). This makes easier to initialize the hotkey system directly.