### PR TITLE
Try to load config from system's config dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +555,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1178,6 +1198,7 @@ dependencies = [
  "backtrace",
  "bytemuck",
  "chrono",
+ "directories",
  "fern",
  "livesplit-core",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 backtrace = "0.3.13"
 bytemuck = "1.4.1"
 chrono = { version = "0.4.0", features = ["serde", "clock"], default-features = false }
+directories = "4.0.1"
 fern = "0.6.0"
 livesplit-core = { git = "https://github.com/LiveSplit/livesplit-core", features = ["software-rendering", "font-loading", "auto-splitting"] }
 log = { version = "0.4.6", features = ["serde"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::stream_markers;
 use core::fmt;
+use directories;
 use livesplit_core::{
     auto_splitting,
     layout::{self, Layout, LayoutSettings},
@@ -13,6 +14,8 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
+
+static CONFIG_FILE_NAME: &'static str = "config.yaml";
 
 #[derive(Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -78,6 +81,18 @@ impl Default for Window {
 }
 
 impl Config {
+    pub fn load() -> Config {
+        match directories::ProjectDirs::from("", "LiveSplit", "LiveSplit One") {
+            Some(project_dirs) => {
+                let config_file_path = project_dirs.config_dir().join(CONFIG_FILE_NAME);
+
+                Config::parse(config_file_path)
+                    .unwrap_or_else(|| Config::parse(CONFIG_FILE_NAME).unwrap_or_default())
+            }
+            None => Config::parse(CONFIG_FILE_NAME).unwrap_or_default(),
+        }
+    }
+
     pub fn parse(path: impl AsRef<Path>) -> Option<Config> {
         let buf = fs::read(path).ok()?;
         serde_yaml::from_slice(&buf).ok()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use minifb::{Key, KeyRepeat};
 static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
-    let config = Config::parse("config.yaml").unwrap_or_default();
+    let config = Config::load();
     config.setup_logging();
 
     let run = config.parse_run_or_default();


### PR DESCRIPTION
Tries to load a config file in the following order:
1. `SYSTEM_CONFIG_DIR/LIVESPLIT_CONFIG_DIR/config.yaml`
2. `./config.yaml`
3. If both above options either don't exist or fail, use Config's `Default::default()`.~

Eventually, we can use directories crate to store splits and auto-splitter files in data_dir() or data_local_dir().